### PR TITLE
update translation file reference

### DIFF
--- a/src/setup.tsx
+++ b/src/setup.tsx
@@ -3,7 +3,7 @@ import getLocale, {
   getTranslationsObject,
   setClientLocale,
 } from './i18n/getLocale.tsx';
-import ja_JP from './translations/ja_JP.json' with { type: 'json' };
+import ja_JP from '../translations/ja_JP.json' with { type: 'json' };
 
 setupFbtee({
   hooks: {


### PR DESCRIPTION
the `translation` directory is on the repo root, and not under `src`

maybe we should have a `tsc --noEmit` step in github actions to ensure that types/references are compiling fine? <picture data-single-emoji=":mild_panic:" title=":mild_panic:"><img class="emoji" width="20" height="auto" src="https://emoji.slack-edge.com/T0CAQ00TU/mild_panic/0326988609f4891a.png" alt=":mild_panic:" align="absmiddle"></picture> 🙏 