### PR TITLE
update expo-build-disk-cache config

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,10 +25,8 @@
     "experiments": {
       "reactCanary": true,
       "reactCompiler": true,
-      "remoteBuildCache": {
-        "provider": {
-          "plugin": "expo-build-disk-cache"
-        }
+      "buildCacheProvider": {
+        "plugin": "expo-build-disk-cache"
       },
       "tsconfigPaths": true,
       "typedRoutes": true

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/react": "~19.1.3",
     "@vitejs/plugin-react": "^4.4.1",
     "eslint": "^9.26.0",
-    "expo-build-disk-cache": "^0.2.0",
+    "expo-build-disk-cache": "^0.3.0",
     "npm-run-all2": "^8.0.1",
     "prettier": "4.0.0-alpha.12",
     "prettier-plugin-packagejson": "^2.5.12",
@@ -83,6 +83,7 @@
     "vitest": "^3.1.3",
     "vitest-react-native": "^0.1.5"
   },
+  "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af",
   "pnpm": {
     "updateConfig": {
       "ignoreDependencies": [

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "vitest": "^3.1.3",
     "vitest-react-native": "^0.1.5"
   },
-  "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af",
   "pnpm": {
     "updateConfig": {
       "ignoreDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,8 +135,8 @@ importers:
         specifier: ^9.26.0
         version: 9.26.0(jiti@1.21.7)
       expo-build-disk-cache:
-        specifier: ^0.2.0
-        version: 0.2.0(typescript@5.8.3)
+        specifier: ^0.3.0
+        version: 0.3.0(typescript@5.8.3)
       npm-run-all2:
         specifier: ^8.0.1
         version: 8.0.1
@@ -2920,8 +2920,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  expo-build-disk-cache@0.2.0:
-    resolution: {integrity: sha512-bJFKQnfBUxgDgnSDAq3/Xue9edK7lEzJtNM9SvnkbhF70tDWrGXbG4G7tF/+tCOaknO2aKSKuhIEhLOKt2G/+Q==}
+  expo-build-disk-cache@0.3.0:
+    resolution: {integrity: sha512-MYn6DGKLugQ2PDmzj9iLAWBO+gGZkKb/FlhrowwCO9iibr5v1oemF6fiw0rVp4Qm22h16OgpHICoSPjSUNGelw==}
     engines: {node: '>=18.0.0'}
 
   expo-constants@17.1.6:
@@ -5689,6 +5689,10 @@ packages:
   xcode@3.0.1:
     resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
     engines: {node: '>=10.0.0'}
+
+  xdg-basedir@5.1.0:
+    resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
+    engines: {node: '>=12'}
 
   xml2js@0.6.0:
     resolution: {integrity: sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==}
@@ -9106,11 +9110,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  expo-build-disk-cache@0.2.0(typescript@5.8.3):
+  expo-build-disk-cache@0.3.0(typescript@5.8.3):
     dependencies:
       '@expo/config': 11.0.10
       cosmiconfig: 9.0.0(typescript@5.8.3)
       env-paths: 3.0.0
+      xdg-basedir: 5.1.0
       zod: 4.0.0-beta.20250505T195954
     transitivePeerDependencies:
       - supports-color
@@ -12175,6 +12180,8 @@ snapshots:
     dependencies:
       simple-plist: 1.3.1
       uuid: 7.0.3
+
+  xdg-basedir@5.1.0: {}
 
   xml2js@0.6.0:
     dependencies:


### PR DESCRIPTION
expo renamed this feature to `bulldCacheProvider` from `remoteBuildCache`).
The old name still works but will be removed in Expo 54.
related PR: https://github.com/expo/expo/pull/36644