### PR TITLE
Fix: Correct fbtee:collect output

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "expo start",
     "dev:setup": "pnpm fbtee",
     "fbtee": "pnpm run fbtee:manifest && pnpm run fbtee:collect && pnpm run fbtee:translate",
-    "fbtee:collect": "fbtee collect --manifest < .src_manifest.json > source_strings.json",
+    "fbtee:collect": "fbtee collect --manifest < .src_manifest.json > .source_strings.json",
     "fbtee:manifest": "fbtee manifest --src src",
     "fbtee:translate": "fbtee translate --translations translations/*.json --jenkins --output-dir src/translations/",
     "format": "prettier --write .",


### PR DESCRIPTION
**Issue Description:**

The `pnpm dev:setup` script was failing with an "ENOENT: no such file or directory" error. This occurred because the `fbtee:translate` step, which is part of the `fbtee` script (called by `dev:setup`), was attempting to read a file named `.source_strings.json`.

However, the preceding `fbtee:collect` step was configured to output this file as `source_strings.json` (i.e., without the leading dot).

**Resolution:**

The `fbtee:collect` script in `package.json` was modified to correctly output the file with a leading dot.

**Original `package.json` script:**
```json
"fbtee:collect": "fbtee collect --manifest < .src_manifest.json > source_strings.json"
```

**Corrected `package.json` script:**
```json
"fbtee:collect": "fbtee collect --manifest < .src_manifest.json > .source_strings.json"
```

This change resolved the script failure.