### PR TITLE
chore: delete unused styled-component recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "styled-components.vscode-styled-components",
     "sysoev.vscode-open-in-github",
     "usernamehw.errorlens",
     "wix.vscode-import-cost"


### PR DESCRIPTION
- Remove the line recommending the use of the styled-component IDE extension.