### PR TITLE
use standard .cache for build disk cache

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,7 +26,13 @@
       "reactCanary": true,
       "reactCompiler": true,
       "buildCacheProvider": {
-        "plugin": "expo-build-disk-cache"
+        "plugin": "expo-build-disk-cache",
+        "options": {
+          "cacheDir": "node_modules/.cache/expo-build-disk-cache",
+          "cacheGcTimeDays": 7,
+          "debug": false,
+          "enable": true
+        }
       },
       "tsconfigPaths": true,
       "typedRoutes": true


### PR DESCRIPTION
PROBLEM:
the default options totally disable the disk cache
under some circumstances. e.g. when using flake.nix instead of homebrew

ALTERNATIVE:
instead of the standard node_modules/.cache, maybe ~/.cache
to allow sharing the build cache across many git worktrees