### PR TITLE
Fixes for the web app, few code tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env.local
 .eslintcache
 .expo/
+.idea
 .metro-health-check*
 *.jks
 *.key

--- a/global.css
+++ b/global.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-screen;
+}

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "prettier": "^3.6.2",
     "prettier-plugin-packagejson": "^2.5.19",
     "prettier-plugin-tailwindcss": "^0.6.14",
+    "react-native-css-interop": "^0.2.0",
     "react-native-svg-transformer": "^1.5.1",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.6.14
         version: 0.6.14(@ianvs/prettier-plugin-sort-imports@4.7.0(@prettier/plugin-oxc@0.0.4)(prettier@3.6.2))(@prettier/plugin-oxc@0.0.4)(prettier@3.6.2)
+      react-native-css-interop:
+        specifier: ^0.2.0
+        version: 0.2.0(react-native-reanimated@4.1.0(patch_hash=f8d3886b1812261ee6440f92ebe2787927c9456d7f9327c80f29901eda434640)(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.1))(react@19.1.1))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.1))(react@19.1.1))(react-native-svg@15.13.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.1))(react@19.1.1)(tailwindcss@3.4.17)
       react-native-svg-transformer:
         specifier: ^1.5.1
         version: 1.5.1(react-native-svg@15.13.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.1))(typescript@5.9.2)

--- a/src/app/(app)/(tabs)/_layout.tsx
+++ b/src/app/(app)/(tabs)/_layout.tsx
@@ -1,4 +1,5 @@
 import _AntDesign from '@expo/vector-icons/AntDesign.js';
+import { type IconProps } from '@expo/vector-icons/build/createIconSet.js';
 import { Tabs } from 'expo-router';
 import { fbs, useLocaleContext } from 'fbtee';
 import { FC, useTransition } from 'react';
@@ -7,11 +8,7 @@ import colors from 'src/ui/colors.ts';
 import Text from 'src/ui/Text.tsx';
 
 // Types in `@expo/vector-icons` do not currently work correctly in `"type": "module"` packages.
-const AntDesign = _AntDesign as unknown as FC<{
-  color: string;
-  name: string;
-  size: number;
-}>;
+const AntDesign = _AntDesign as unknown as FC<IconProps<string>>;
 
 export default function TabLayout() {
   const [, startTransition] = useTransition();
@@ -21,9 +18,9 @@ export default function TabLayout() {
     <Tabs
       screenOptions={{
         sceneStyle: {
-          backgroundColor: 'transparent',
+          backgroundColor: colors.screen,
         },
-        tabBarActiveTintColor: colors.purple,
+        tabBarActiveTintColor: colors.accent,
       }}
     >
       <Tabs.Screen
@@ -51,7 +48,7 @@ export default function TabLayout() {
           ),
           tabBarIcon: ({ focused }: { focused: boolean }) => (
             <AntDesign
-              color={focused ? colors.purple : colors.black}
+              color={focused ? colors.accent : colors.text}
               name="ie"
               size={24}
             />
@@ -64,7 +61,7 @@ export default function TabLayout() {
         options={{
           tabBarIcon: ({ focused }: { focused: boolean }) => (
             <AntDesign
-              color={focused ? colors.purple : colors.black}
+              color={focused ? colors.accent : colors.text}
               name="printer"
               size={24}
             />

--- a/src/app/(app)/(tabs)/index.tsx
+++ b/src/app/(app)/(tabs)/index.tsx
@@ -2,6 +2,7 @@ import Stack, { VStack } from '@nkzw/stack';
 import { Stack as ExpoStack } from 'expo-router';
 import { fbs } from 'fbtee';
 import { View } from 'react-native';
+import { cx } from 'src/lib/cx.tsx';
 import Text from 'src/ui/Text.tsx';
 
 export default function Index() {
@@ -11,7 +12,7 @@ export default function Index() {
         options={{ title: String(fbs('Home', 'Home header title')) }}
       />
       <VStack alignCenter center flex1 gap={16} padding>
-        <Text className="text-center text-xl font-bold color-purple">
+        <Text className="text-center text-xl font-bold color-accent">
           <fbt desc="Greeting">Welcome</fbt>
         </Text>
         <Text className="text-center italic">
@@ -21,7 +22,12 @@ export default function Index() {
           <Text className="text-center">
             <fbt desc="Live update message">
               Change{' '}
-              <View className="border-hairline translate-y-[8px] rounded border-purple bg-grey p-1">
+              <View
+                className={cx(
+                  'inline-flex rounded border border-accent bg-subtle p-1',
+                  'android:translate-y-[9px] ios:translate-y-[9px]',
+                )}
+              >
                 <Text>src/app/(app)/(tabs)/index.tsx</Text>
               </View>{' '}
               for live updates.

--- a/src/app/+html.tsx
+++ b/src/app/+html.tsx
@@ -1,11 +1,11 @@
 import { ScrollViewStyleReset } from 'expo-router/html.js';
-import { ReactNode } from 'react';
+import { type PropsWithChildren } from 'react';
 
 // This file is web-only and used to configure the root HTML for every
 // web page during static rendering.
 // The contents of this function only run in Node.js environments and
 // do not have access to the DOM or browser APIs.
-export default function Root({ children }: { children: ReactNode }) {
+export default function Root({ children }: PropsWithChildren) {
   return (
     <html lang="en">
       <head>
@@ -27,21 +27,9 @@ export default function Root({ children }: { children: ReactNode }) {
         */}
         <ScrollViewStyleReset />
 
-        {/* Using raw CSS styles as an escape-hatch to ensure the background color never flickers in dark-mode. */}
-        <style dangerouslySetInnerHTML={{ __html: responsiveBackground }} />
         {/* Add any additional <head> elements that you want globally available on web... */}
       </head>
       <body>{children}</body>
     </html>
   );
 }
-
-const responsiveBackground = `
-body {
-  background-color: #fff;
-}
-@media (prefers-color-scheme: dark) {
-  body {
-    background-color: #000;
-  }
-}`;

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout() {
     <LocaleContext>
       <ViewerContext>
         <GestureHandlerRootView>
-          <VStack flex1>
+          <VStack className="!basis-full" flex1>
             <Slot />
           </VStack>
         </GestureHandlerRootView>

--- a/src/app/login.tsx
+++ b/src/app/login.tsx
@@ -16,7 +16,7 @@ export default function Login() {
 
   return (
     <SafeAreaView className="flex-1">
-      <Stack alignCenter center flex1 padding={16}>
+      <Stack alignCenter center className="!basis-full" flex1 padding={16}>
         <Text className="w-full text-center text-lg" onPress={onPress}>
           <fbt desc="Login button">Login</fbt>
         </Text>

--- a/src/ui/colors.ts
+++ b/src/ui/colors.ts
@@ -1,8 +1,8 @@
 const colors = {
-  black: '#111',
-  grey: '#ededed',
-  purple: '#7e22ce',
-  white: '#fff',
+  accent: '#7e22ce',
+  screen: '#fff',
+  subtle: '#ededed',
+  text: '#111',
 };
 
 export type ColorName = keyof typeof colors;


### PR DESCRIPTION
# Why

After playing a bit with template I have spotted that the web part is a bit broken (if user prefers dark mode, the "Login" button is not visible, and after login the screens contant is collapsed due to `flexBasis: 0%` style from `Stack`/`VStack` components - this ideally should be addressed in the code of packages exposing those components.

### Web issues

https://github.com/user-attachments/assets/a0d4ce4b-ec85-4155-9ae7-db4972fca32e

# How

Summary of changes in this PR:
* add `!basis-full` class to `Stack`/`VStack` wrappers in layouts (unfortunately Nativewind does not expose `web:` scope, so the changes have to be applied globally, but they does not affect mobile apps
* add `react-native-css-interop` to the `devDependencies` which cannot be properly resolved after recent hoisting changes
* replace `sceneStyle` transparent background with screen color, to avoid screen content overlapping on the web
* remove very simple relative background setup from `+html.tsx` since it causes an issues without a proper theming solution based on Nativewind working across all three supported platforms (I'm happy to work in the near future on contribution adding that)
* rename colors with semantic names in preparation for theming support (they would be confusing when dark mode is added)
* remove translate style from the inline code block on web (as mentioned above Nativewind does not expose `web:` scope, so I had to use classes with scopes based on native platforms)
* replace manually typed `@expo/vector-icons` props with type exposed by the set helper to avoid manual props typing, however the point about proper types is still valid, and cast is still needed

# Preview

### Web

https://github.com/user-attachments/assets/83c47f5e-0914-4274-9e69-eb8cf55cf9da

### iOS

https://github.com/user-attachments/assets/5810784a-f3a1-4455-abac-4512de0a6cf6

